### PR TITLE
Update Luacheck link

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1987,7 +1987,7 @@ local sources = { null_ls.builtins.diagnostics.jsonlint }
 - `command = "jsonlint"`
 - `args = { "--compact" }`
 
-#### [luacheck](https://github.com/mpeterv/luacheck)
+#### [luacheck](https://github.com/lunarmodules/luacheck)
 
 ##### About
 


### PR DESCRIPTION
Update Luacheck link to the official repo: https://github.com/lunarmodules/luacheck